### PR TITLE
Play! 1.4.x: Update dependencies.xml for Play! 1.4.6 compatibility

### DIFF
--- a/conf/dependencies.yml
+++ b/conf/dependencies.yml
@@ -1,4 +1,4 @@
 # openseedbox-common dependencies
 
 require:
-    - play [1.3.4,1.4[
+    - play [1.3.4,1.5[


### PR DESCRIPTION
Fix for:

```
~ *****************************************************************************
~
~ WARNING: These dependencies are missing, your application may not work properly (use --verbose for details),
~
~
~
~	play->play [1.3.4,1.4[
~
~	play->play [1.3.4,1.4[: not found
~
~ *****************************************************************************
~
~ Some dependencies are still missing.
```